### PR TITLE
Fix cores object definition in App.jsx

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1725,6 +1725,7 @@ escolherMateria: (
                   Bloco1: "bg-red-600",
                   Bloco2: "bg-yellow-600",
                   Bloco3: "bg-green-600",
+                };
                 return (
                   <div
                     key={idx}


### PR DESCRIPTION
## Summary
- add missing closing brace and semicolon to `cores` object in `blocos.map`

## Testing
- `npm run build` *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685b3c5638148328a10af508b1c84f8d